### PR TITLE
feat(ci): use archifiltre.fabrique.social.gouv.fr

### DIFF
--- a/.k8s/components/app.ts
+++ b/.k8s/components/app.ts
@@ -3,7 +3,7 @@ import env from "@kosko/env";
 import { create } from "@socialgouv/kosko-charts/components/nginx";
 
 const manifests = create({
-  env
+  env,
 });
 
 export default manifests;

--- a/.k8s/environments/prod/app.ts
+++ b/.k8s/environments/prod/app.ts
@@ -1,0 +1,5 @@
+import { GlobalEnvironment } from "@socialgouv/kosko-charts/types";
+
+export default {
+  subdomain: `archifiltre`,
+} as Partial<GlobalEnvironment>;


### PR DESCRIPTION
Ceci override le ndd par défaut qui est lié au nom du projet